### PR TITLE
Add descriptive alt text for farm photos

### DIFF
--- a/農業剪影.html
+++ b/農業剪影.html
@@ -21,8 +21,8 @@
         <div id="banner"></div>
         <div id="mainContent">   
             <div id="content">
-                <img  src="圖片/IMG20250403094049.jpg" alt="錯誤">
-                <img  src="圖片/IMG20250403094429.jpg" alt="錯誤">
+                <img  src="圖片/IMG20250403094049.jpg" alt="農場綠意與田埂的景致">
+                <img  src="圖片/IMG20250403094429.jpg" alt="穿紅色上衣的農友在田間搬運農事器具">
             </div>
         </div>
         <div id="footer">©2025/4/4  田翔版權所有</div>

--- a/農業日誌.html
+++ b/農業日誌.html
@@ -22,7 +22,7 @@
         <div id="mainContent">   
             <div id="content">
                 <p>會用推車挖牛糞</p>
-                <img id="日誌" src="圖片/IMG20250403094116.jpg" alt="錯誤">
+                <img id="日誌" src="圖片/IMG20250403094116.jpg" alt="推車停在堆肥場旁準備鏟取牛糞">
                 <p>牛糞會堆肥大約六個月
                     <br>
                     種的時候會使用椰子殼


### PR DESCRIPTION
## Summary
- replace placeholder alt text on the farm photo gallery with descriptions of the scenery and activity shown
- add a meaningful alt description for the diary image describing the wheelbarrow and compost work

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccdb5fb2a4832e909f65203d9072ed